### PR TITLE
com.webos.surfacemanager.json: Add displayConfig

### DIFF
--- a/configs/layers/base/grouper/com.webos.surfacemanager.json
+++ b/configs/layers/base/grouper/com.webos.surfacemanager.json
@@ -1,3 +1,8 @@
 {
-    "compositorGeometry": "800x1280+0+0r0s1"
+    "compositorGeometry": "800x1280+0+0r0s1",
+    "displayConfig": [
+        { 
+            "machine": "grouper"
+        }
+    ]
 }

--- a/configs/layers/base/hammerhead/com.webos.surfacemanager.json
+++ b/configs/layers/base/hammerhead/com.webos.surfacemanager.json
@@ -1,3 +1,8 @@
 {
-    "compositorGeometry": "1080x1920+0+0r0s1"
+    "compositorGeometry": "1080x1920+0+0r0s1",
+    "displayConfig": [
+        { 
+            "machine": "hammerhead"
+        }
+    ]
 }

--- a/configs/layers/base/maguro/com.webos.surfacemanager.json
+++ b/configs/layers/base/maguro/com.webos.surfacemanager.json
@@ -1,3 +1,8 @@
 {
-    "compositorGeometry": "720x1280+0+0r0s1"
+    "compositorGeometry": "720x1280+0+0r0s1",
+    "displayConfig": [
+        { 
+            "machine": "maguro"
+        }
+    ]
 }

--- a/configs/layers/base/mako/com.webos.surfacemanager.json
+++ b/configs/layers/base/mako/com.webos.surfacemanager.json
@@ -1,3 +1,8 @@
 {
-    "compositorGeometry": "768x1280+0+0r0s1"
+    "compositorGeometry": "768x1280+0+0r0s1",
+    "displayConfig": [
+        { 
+            "machine": "mako"
+        }
+    ]
 }

--- a/configs/layers/base/mido/com.webos.surfacemanager.json
+++ b/configs/layers/base/mido/com.webos.surfacemanager.json
@@ -1,3 +1,8 @@
 {
-    "compositorGeometry": "1080x1920+0+0r0s1"
+    "compositorGeometry": "1080x1920+0+0r0s1",
+    "displayConfig": [
+        { 
+            "machine": "mido"
+        }
+    ]
 }

--- a/configs/layers/base/onyx/com.webos.surfacemanager.json
+++ b/configs/layers/base/onyx/com.webos.surfacemanager.json
@@ -1,3 +1,8 @@
 {
-    "compositorGeometry": "1080x1920+0+0r0s1"
+    "compositorGeometry": "1080x1920+0+0r0s1",
+    "displayConfig": [
+        { 
+            "machine": "onyx"
+        }
+    ]
 }

--- a/configs/layers/base/oxygen/com.webos.surfacemanager.json
+++ b/configs/layers/base/oxygen/com.webos.surfacemanager.json
@@ -1,3 +1,8 @@
 {
-    "compositorGeometry": "1080x1920+0+0r0s1"
+    "compositorGeometry": "1080x1920+0+0r0s1",
+    "displayConfig": [
+        { 
+            "machine": "oxygen"
+        }
+    ]
 }

--- a/configs/layers/base/rosy/com.webos.surfacemanager.json
+++ b/configs/layers/base/rosy/com.webos.surfacemanager.json
@@ -1,3 +1,8 @@
 {
-    "compositorGeometry": "720x1440+0+0r0s1"
+    "compositorGeometry": "720x1440+0+0r0s1",
+    "displayConfig": [
+        { 
+            "machine": "rosy"
+        }
+    ]
 }

--- a/configs/layers/base/s2/com.webos.surfacemanager.json
+++ b/configs/layers/base/s2/com.webos.surfacemanager.json
@@ -1,3 +1,8 @@
 {
-    "compositorGeometry": "1080x1920+0+0r0s1"
+    "compositorGeometry": "1080x1920+0+0r0s1",
+    "displayConfig": [
+        { 
+            "machine": "s2"
+        }
+    ]
 }

--- a/configs/layers/base/sagit/com.webos.surfacemanager.json
+++ b/configs/layers/base/sagit/com.webos.surfacemanager.json
@@ -1,3 +1,8 @@
 {
-    "compositorGeometry": "1080x1920+0+0r0s1"
+    "compositorGeometry": "1080x1920+0+0r0s1",
+    "displayConfig": [
+        { 
+            "machine": "sagit"
+        }
+    ]
 }

--- a/configs/layers/base/sargo/com.webos.surfacemanager.json
+++ b/configs/layers/base/sargo/com.webos.surfacemanager.json
@@ -1,3 +1,8 @@
 {
-    "compositorGeometry": "1080x2220+0+0r0s1"
+    "compositorGeometry": "1080x2220+0+0r0s1",
+    "displayConfig": [
+        { 
+            "machine": "sargo"
+        }
+    ]
 }

--- a/configs/layers/base/tenderloin/com.webos.surfacemanager.json
+++ b/configs/layers/base/tenderloin/com.webos.surfacemanager.json
@@ -1,3 +1,8 @@
 {
-    "compositorGeometry": "1024x768+0+0r0s1"
+    "compositorGeometry": "1024x768+0+0r0s1",
+    "displayConfig": [
+        { 
+            "machine": "tenderloin"
+        }
+    ]
 }

--- a/configs/layers/base/tissot/com.webos.surfacemanager.json
+++ b/configs/layers/base/tissot/com.webos.surfacemanager.json
@@ -1,3 +1,8 @@
 {
-    "compositorGeometry": "1080x1920+0+0r0s1"
+    "compositorGeometry": "1080x1920+0+0r0s1",
+    "displayConfig": [
+        { 
+            "machine": "tissot"
+        }
+    ]
 }

--- a/configs/layers/base/yggdrasil/com.webos.surfacemanager.json
+++ b/configs/layers/base/yggdrasil/com.webos.surfacemanager.json
@@ -1,3 +1,8 @@
 {
-    "compositorGeometry": "1080x2340+0+0r0s1"
+    "compositorGeometry": "1080x2340+0+0r0s1",
+    "displayConfig": [
+        { 
+            "machine": "yggdrasil"
+        }
+    ]
 }


### PR DESCRIPTION
Add displayConfig.json for our Halium targets to avoid automatic detection of displays by luna-surfacemanager which causes the UI not to work on Halium based targets.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>