### PR TITLE
com.webos.surfacemanager.json: Fix display on PT2

### DIFF
--- a/configs/layers/base/pinetab2/com.webos.surfacemanager.json
+++ b/configs/layers/base/pinetab2/com.webos.surfacemanager.json
@@ -1,4 +1,4 @@
 {
-    "compositorGeometry": "1280x800+0+0r0s1",
+    "compositorGeometry": "800x1280+0+0r90s1",
     "devicePixelRatio": "1.0"
 }


### PR DESCRIPTION
Resolution needs to be set to 800x1280 instead of 1280x800 and rotation needs to be 90 degrees.