### PR TITLE
com.webos.surfacemanager.json: Add file for mido-halium

### DIFF
--- a/configs/layers/base/mido-halium/com.webos.surfacemanager.json
+++ b/configs/layers/base/mido-halium/com.webos.surfacemanager.json
@@ -1,0 +1,9 @@
+{
+    "compositorGeometry": "1080x1920+0+0r0s1",
+    "devicePixelRatio": "2.6",
+    "displayConfig": [
+        { 
+            "machine": "mido"
+        }
+    ]
+}


### PR DESCRIPTION
After the split between mainline and Halium we need a separate config file for the Halium variant as well.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>